### PR TITLE
Correção: vencedor da votação biblioteca

### DIFF
--- a/aula-4/app/biblioteca.jsx
+++ b/aula-4/app/biblioteca.jsx
@@ -5,10 +5,10 @@ import { Badge, Card } from "flowbite-react";
 export default function Biblioteca({ text, votes, winner }) {
     return (
         <Card className="w-44 h-36 text-center font-medium">
-            <span className="flex justify-center">
-                {winner && <Badge className="w-fit" size="xs" color="success">Vencedor</Badge>}
-            </span>
             {text} {winner && `- ${votes}`}
+            <span className="flex justify-center">
+                {winner == String(text).toLowerCase() && <Badge className="w-fit" size="xs" color="success">Vencedor</Badge>}
+            </span>
         </Card>
     )
 }


### PR DESCRIPTION
Ao finalizar a votação, todos os items apareciam com a badge de vencedor. Corrigido para apenas o vencedor aparecer com a badge